### PR TITLE
Allow to use setCaptureElements with render

### DIFF
--- a/lib/client-wrapper.js
+++ b/lib/client-wrapper.js
@@ -29,6 +29,7 @@ SuiteBuilderStub.prototype.ignoreElements = chainNoOp;
 SuiteBuilderStub.prototype.skip = chainNoOp;
 SuiteBuilderStub.prototype.browsers = chainNoOp;
 SuiteBuilderStub.prototype.includeCss = chainNoOp;
+SuiteBuilderStub.prototype.setCaptureElements = chainNoOp;
 
 SuiteBuilderStub.prototype.render = function(element) {
     ReactDOM.render(

--- a/lib/server-suite-wrapper.js
+++ b/lib/server-suite-wrapper.js
@@ -22,7 +22,7 @@ class ServerSuireWrapper {
     render() {
         const url = this._server.registerRender();
         this._original.setUrl(url);
-        this._original.setCaptureElements([RENDER_TARGET_SELECTOR]);
+        this._original.setCaptureElements(this._captureElements || RENDER_TARGET_SELECTOR);
         this._original.before(function(actions, find) {
             this.renderedComponent = find(RENDER_TARGET_SELECTOR);
         });
@@ -38,8 +38,12 @@ class ServerSuireWrapper {
         throw new Error('Do not call setUrl manually, use render(<ReactComponent />) instead');
     }
 
-    setCaptureElements() {
-        throw new Error('Do not call setCaptureElements manually, use render(<ReactComponent />) instead');
+    setCaptureElements(elements) {
+        if (elements && elements.length) {
+            this._captureElements = elements;
+            return this;
+        }
+        throw new Error('Do not call setCaptureElements without selectors, use render(<ReactComponent />) instead');
     }
 }
 


### PR DESCRIPTION
Suitable for complex cases when you need to capture not only rendered at mounting node component, but also elements outside this node (for example: case with select's popup, where popup will be rendered separately in the end of `body`).
