### PR TITLE
Remove redundant husky dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "eslint-config-gemini-testing": "^2.3.0",
     "express": "^4.14.0",
     "gemini": "^4.12.2",
-    "husky": "^0.11.9",
     "lodash": "^4.16.4",
     "mkdirp": "^0.5.1",
     "mocha": "^3.1.2",


### PR DESCRIPTION
The dependency on husky was added twice to package.json. I've remove it from "dependencies" and left the one that was added to "devDependencies".
